### PR TITLE
Switch baseurls from mjanja to hpc

### DIFF
--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -12,28 +12,28 @@
 
 [base]
 name=CentOS-$releasever - Base
-baseurl=http://mirror.mjanja.co.ke/centos/$releasever/os/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
-baseurl=http://mirror.mjanja.co.ke/centos/$releasever/updates/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-baseurl=http://mirror.mjanja.co.ke/centos/$releasever/extras/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-baseurl=http://mirror.mjanja.co.ke/centos/$releasever/centosplus/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/centosplus/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -41,7 +41,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-baseurl=http://mirror.mjanja.co.ke/centos/$releasever/contrib/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/contrib/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/epel.repo
+++ b/epel.repo
@@ -1,6 +1,6 @@
 [epel]
 name=Extra Packages for Enterprise Linux 6 - $basearch
-baseurl=http://mirror.mjanja.co.ke/epel/6/$basearch
+baseurl=http://hpc.ilri.cgiar.org/mirror/epel/6/$basearch
 failovermethod=priority
 enabled=1
 gpgcheck=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
 
 [epel-debuginfo]
 name=Extra Packages for Enterprise Linux 6 - $basearch - Debug
-baseurl=http://mirror.mjanja.co.ke/epel/6/$basearch/debug
+baseurl=http://hpc.ilri.cgiar.org/mirror/epel/6/$basearch/debug
 failovermethod=priority
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
@@ -16,7 +16,7 @@ gpgcheck=1
 
 [epel-source]
 name=Extra Packages for Enterprise Linux 6 - $basearch - Source
-baseurl=http://mirror.mjanja.co.ke/epel/6/SRPMS
+baseurl=http://hpc.ilri.cgiar.org/mirror/epel/6/SRPMS
 failovermethod=priority
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6

--- a/fedora-updates.repo
+++ b/fedora-updates.repo
@@ -1,7 +1,7 @@
 [updates]
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
-baseurl=http://mirror.mjanja.co.ke/fedora/linux/updates/$releasever/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/fedora/linux/updates/$releasever/$basearch/
 #mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 enabled=1
 gpgcheck=1

--- a/fedora.repo
+++ b/fedora.repo
@@ -1,7 +1,7 @@
 [fedora]
 name=Fedora $releasever - $basearch
 failovermethod=priority
-baseurl=http://mirror.mjanja.co.ke/fedora/linux/releases/$releasever/Everything/$basearch/os/
+baseurl=http://hpc.ilri.cgiar.org/mirror/fedora/linux/releases/$releasever/Everything/$basearch/os/
 enabled=1
 metadata_expire=7d
 gpgcheck=1


### PR DESCRIPTION
[mirror.mjanja.co.ke](http://mirror.mjanja.co.ke) will soon be depricated in favor of [hpc.ilri.cgiar.org](http://hpc.ilri.cgiar.org/mirror) :cry: 
Besides that, both domains are just vhosts in the same machine serving data from the same source :wink: 