### PR TITLE
Switch Arch's mirror URL to hpc

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                 <section>
                     <h3 id="arch">Arch Linux</h3>
                     <p>Add the following to the top of your <code>/etc/pacman.d/mirrorlist</code>:</p>
-                    <pre><code>Server = http://mirror.mjanja.co.ke/archlinux/$repo/os/$arch</code></pre>
+                    <pre><code>Server = http://hpc.ilri.cgiar.org/mirror/archlinux/$repo/os/$arch</code></pre>
                 </section>
                 <section>
                     <h3 id="centos">CentOS</h3>


### PR DESCRIPTION
Use [hpc.ilri.cgiar.org/mirror](http://hpc.ilri.cgiar.org/mirror) for the mirror URL instead of [mirror.mjanja.co.ke](http://mirror.mjanja.co.ke).