### PR TITLE
Centos fixes

### DIFF
--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -14,21 +14,21 @@
 name=CentOS-$releasever - Base
 baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/os/$basearch/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
 
 #released updates 
 [updates]
 name=CentOS-$releasever - Updates
 baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/updates/$basearch/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
 
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
 baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/extras/$basearch/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
 
 #additional packages that extend functionality of existing packages
 [centosplus]
@@ -36,7 +36,7 @@ name=CentOS-$releasever - Plus
 baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/centosplus/$basearch/
 gpgcheck=1
 enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
 
 #contrib - packages by Centos Users
 [contrib]
@@ -44,4 +44,4 @@ name=CentOS-$releasever - Contrib
 baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/contrib/$basearch/
 gpgcheck=1
 enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever

--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
                     <p>Use <em>mirror.mjanja.co.ke</em> in your <code>/etc/yum.repos.d/CentOS-Base.repo</code>, ie:
                     <pre><code>[base]
 name=CentOS-$releasever - Base
-baseurl=http://mirror.mjanja.co.ke/centos/$releasever/os/$basearch/
+baseurl=http://hpc.ilri.cgiar.org/mirror/centos/$releasever/os/$basearch/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6</code></pre>
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever</code></pre>
 </p>
                 <p>Alternatively, download this <code><a href="CentOS-Base.repo">CentOS-Base.repo</a></code>.</p>
                 <p><strong>EPEL is also available</strong>. Use:


### PR DESCRIPTION
Instead of adding a new `CentOS-Base.repo` yum repo file for CentOS 7, I think we should just use `$releasever` to get CentOS version instead of hard-coding it in the same file.