### PR TITLE
Fedora fixes

### DIFF
--- a/fedora-updates.repo
+++ b/fedora-updates.repo
@@ -2,25 +2,31 @@
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
 baseurl=http://hpc.ilri.cgiar.org/mirror/fedora/linux/updates/$releasever/$basearch/
-#mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 enabled=1
 gpgcheck=1
+metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
 
 [updates-debuginfo]
 name=Fedora $releasever - $basearch - Updates - Debug
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/$releasever/$basearch/debug/
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch
 enabled=0
 gpgcheck=1
+metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
 
 [updates-source]
 name=Fedora $releasever - Updates Source
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/$releasever/SRPMS/
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch
 enabled=0
 gpgcheck=1
+metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/fedora.repo
+++ b/fedora.repo
@@ -6,23 +6,26 @@ enabled=1
 metadata_expire=7d
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
 
 [fedora-debuginfo]
 name=Fedora $releasever - $basearch - Debug
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/debug/
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
 
 [fedora-source]
 name=Fedora $releasever - Source
 failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/source/SRPMS/
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/index.html
+++ b/index.html
@@ -74,15 +74,17 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6</code></pre>
                 </section>
                 <section>
                     <h3 id="fedora">Fedora</h3>
-                    <p>Currently provides Fedora 18 - 22 (no debug, armhfp, or SRPMs).  Use <em>mirror.mjanja.co.ke</em> in your <code>/etc/yum.repos.d/fedora{-updates}.repo</code>, ie:
+                    <p>Currently provides Fedora 21 & 22 (no debug, armhfp, or SRPMs).  Use <em>mirror.mjanja.co.ke</em> in your <code>/etc/yum.repos.d/fedora{-updates}.repo</code>, ie:
                     <pre><code>[fedora]
 name=Fedora $releasever - $basearch
 failovermethod=priority
-baseurl=http://mirror.mjanja.co.ke/fedora/linux/releases/$releasever/Everything/$basearch/os/
+baseurl=http://hpc.ilri.cgiar.org/mirror/fedora/linux/releases/$releasever/Everything/$basearch/os/
 enabled=1
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch</code></pre>
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+</code></pre>
 </p>
                 <p>Alternatively, download <code><a href="fedora.repo">fedora.repo</a></code> and <code><a href="fedora-updates.repo">fedora-updates.repo</a></code>.</p>
                 </section>


### PR DESCRIPTION
I've made a few changes to the `fedora-updates.repo` & `fedora.repo` yum repo files to match the ones from vanilla fedora 21 & 22.
I've also removed Fedora 18 info from `index.html` file.
